### PR TITLE
Additional plane endpoints for the game

### DIFF
--- a/src/main/java/com/planespotter/backend/controllers/PlaneController.java
+++ b/src/main/java/com/planespotter/backend/controllers/PlaneController.java
@@ -19,6 +19,19 @@ public class PlaneController {
     }
 
     /**
+     * GET endpoint to get all planes from the database.
+     * @return List of all planes in the database, or 404s if the database is empty.
+     */
+    @GetMapping
+    public ResponseEntity<List<Plane>> getAllPlanes() {
+        List<Plane> planes = planeRepository.getAllPlanes();
+        if (planes.isEmpty()) {
+            return ResponseEntity.notFound().build();
+        }
+        return ResponseEntity.ok(planes);
+    }
+
+    /**
      * GET endpoint to get a list of planes with the matching name i.e. "Boeing" would return 737, 747, 757, etc...
      * @param name Part or whole name of the plane to match.
      * @return List of planes matching the provided name, or 404s if no matches are found.
@@ -27,6 +40,20 @@ public class PlaneController {
     public ResponseEntity<List<Plane>> getPlaneByName(@RequestParam("name") String name) {
         List<Plane> planes = planeRepository.getByName(name);
         if (planes.isEmpty()) {
+            return ResponseEntity.notFound().build();
+        }
+        return ResponseEntity.ok(planes);
+    }
+
+    /**
+     * GET endpoint to get four planes for the game.
+     * The frontend will handle logic for getting a photo for one of the planes returned by this endpoint.
+     * @return A list of four random Planes from the database, or a 404 if the database is empty/less than four are in the DB.
+     */
+    @GetMapping("/getForGame")
+    public ResponseEntity<List<Plane>> getPlanesForGame() {
+        List<Plane> planes = planeRepository.getPlanesForGame();
+        if (planes.size() < 4) {
             return ResponseEntity.notFound().build();
         }
         return ResponseEntity.ok(planes);

--- a/src/main/java/com/planespotter/backend/repositories/PlaneRepository.java
+++ b/src/main/java/com/planespotter/backend/repositories/PlaneRepository.java
@@ -16,6 +16,12 @@ public interface PlaneRepository extends JpaRepository<Plane, Long> {
     @Query(value = "SELECT * FROM \"plane\" WHERE plane_id = :id", nativeQuery = true)
     Plane getById(long id);
 
+    @Query(value = "SELECT * FROM \"plane\" ORDER BY RANDOM() LIMIT 4", nativeQuery = true)
+    List<Plane> getPlanesForGame();
+
+    @Query(value = "SELECT * FROM \"plane\"", nativeQuery = true)
+    List<Plane> getAllPlanes();
+
     @Transactional
     @Modifying
     @Query(value = "INSERT INTO \"plane\" (user_id, name) VALUES " +

--- a/src/test/java/com/planespotter/backend/ControllerTests/PlaneControllerTest.java
+++ b/src/test/java/com/planespotter/backend/ControllerTests/PlaneControllerTest.java
@@ -34,6 +34,11 @@ public class PlaneControllerTest {
     }
 
     @Test
+    void getAllPlanes_returnsListOfPlanes() {
+
+    }
+
+    @Test
     void getPlaneByName_returnsListOfPlanes() {
         List<Plane> planes = Arrays.asList(new Plane(0, "plane 1"),
                                             new Plane(1, "plane 2"));

--- a/src/test/java/com/planespotter/backend/ControllerTests/PlaneControllerTest.java
+++ b/src/test/java/com/planespotter/backend/ControllerTests/PlaneControllerTest.java
@@ -35,7 +35,60 @@ public class PlaneControllerTest {
 
     @Test
     void getAllPlanes_returnsListOfPlanes() {
+        List<Plane> planes  = Arrays.asList(new Plane(0, "plane"),
+                                            new Plane(1, "plane"));
+        when(planeRepository.getAllPlanes()).thenReturn(planes);
 
+        ResponseEntity<List<Plane>> response = planeController.getAllPlanes();
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(2, response.getBody().size());
+        assertEquals(planes, response.getBody());
+    }
+
+    @Test
+    void getAllPlanes_404OnEmptyList() {
+        when(planeRepository.getAllPlanes()).thenReturn(List.of());
+
+        ResponseEntity<List<Plane>> response = planeController.getAllPlanes();
+
+        assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+    }
+
+    @Test
+    void getPlanesForGame_returnsListOfPlanes() {
+        List<Plane> planes = Arrays.asList(new Plane(0, "plane"),
+                                            new Plane(1, "plane"),
+                                            new Plane(2, "plane"),
+                                            new Plane(3, "plane"));
+        when(planeRepository.getPlanesForGame()).thenReturn(planes);
+
+        ResponseEntity<List<Plane>> response = planeController.getPlanesForGame();
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(4, response.getBody().size());
+        assertEquals(planes, response.getBody());
+    }
+
+    @Test
+    void getPlanesForGame_404IfLessThanFourPlanes() {
+        List<Plane> planes = Arrays.asList(new Plane(0, "plane"),
+                                            new Plane(1, "plane"),
+                                            new Plane(2, "plane"));
+        when(planeRepository.getPlanesForGame()).thenReturn(planes);
+
+        ResponseEntity<List<Plane>> response = planeController.getPlanesForGame();
+
+        assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+    }
+
+    @Test
+    void getPlanesForGame_404OnEmptyList() {
+        when(planeRepository.getPlanesForGame()).thenReturn(List.of());
+
+        ResponseEntity<List<Plane>> response = planeController.getPlanesForGame();
+
+        assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
     }
 
     @Test


### PR DESCRIPTION
- Added `/getAllPlanes` as an endpoint as a formality.
- Added `/getPlanesForGame` that returns four random planes from the DB for use by our game. The frontend will handle the logic of getting a photo for a random one of the four planes.
- Wrote tests for those endpoints and all are passing