### PR TITLE
Added getLeaderboard Endpoint

### DIFF
--- a/src/main/java/com/planespotter/backend/controllers/StatsController.java
+++ b/src/main/java/com/planespotter/backend/controllers/StatsController.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import java.util.List;
 
 @RestController
 @RequestMapping("/stats")
@@ -35,5 +36,11 @@ public class StatsController {
             return ResponseEntity.notFound().build();
         }
         return ResponseEntity.ok(stats);
+    }
+
+    @GetMapping("/getLeaderboard")
+    public ResponseEntity<List<Stats>> getLeaderboard(){
+        List<Stats> leaderboard = statsRepository.findTop10ByOrderByBestStreakDesc();
+        return ResponseEntity.ok(leaderboard);
     }
 }

--- a/src/main/java/com/planespotter/backend/repositories/StatsRepository.java
+++ b/src/main/java/com/planespotter/backend/repositories/StatsRepository.java
@@ -4,8 +4,10 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import com.planespotter.backend.entities.User;
 import com.planespotter.backend.entities.Stats;
 import org.springframework.stereotype.Repository;
+import java.util.List;
 
 @Repository
 public interface StatsRepository extends JpaRepository<Stats, Long> {
     Stats findByUser(User user);
+    List<Stats> findTop10ByOrderByBestStreakDesc();
 }


### PR DESCRIPTION
Added GET /getLeaderboard endpoint to return top 10 players ordered by best streak descending. Uses Spring Data JPA's findTop10ByOrderByBestStreakDesc() to auto-generate the query.