### PR TITLE
Added unit tests for OAuth services and AuthController

### DIFF
--- a/src/test/java/com/planespotter/backend/auth/AuthControllerTest.java
+++ b/src/test/java/com/planespotter/backend/auth/AuthControllerTest.java
@@ -1,0 +1,107 @@
+package com.planespotter.backend.auth;
+
+import com.planespotter.backend.auth.dto.AuthResponse;
+import com.planespotter.backend.auth.dto.GitHubAuthRequest;
+import com.planespotter.backend.auth.dto.GoogleAuthRequest;
+import com.planespotter.backend.entities.User;
+import com.planespotter.backend.repositories.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+public class AuthControllerTest {
+    @Mock private GoogleIdTokenService googleService;
+    @Mock private GitHubOAuthService githubService;
+    @Mock private JwtService jwt;
+    @Mock private UserRepository users;
+
+    @InjectMocks private AuthController controller;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void google_success_newUser_returnsJwtAndCreatesUser() {
+        when(googleService.verify("idtok"))
+                .thenReturn(new GoogleIdTokenService.VerifiedGoogleUser("new@example.com", "google-sub-1"));
+        when(users.findByEmail("new@example.com")).thenReturn(null);
+        User saved = new User(7L, null, "new@example.com", false);
+        when(users.save(any(User.class))).thenReturn(saved);
+        when(jwt.issue("new@example.com", 7L)).thenReturn("fake-jwt");
+
+        ResponseEntity<AuthResponse> res = controller.google(new GoogleAuthRequest("idtok"));
+
+        assertEquals(HttpStatus.OK, res.getStatusCode());
+        assertNotNull(res.getBody());
+        assertEquals("fake-jwt", res.getBody().token());
+        assertEquals("new@example.com", res.getBody().user().email());
+        verify(users).save(any(User.class));
+    }
+
+    @Test
+    void google_success_existingUser_doesNotSave() {
+        User existing = new User(3L, null, "old@example.com", false);
+        when(googleService.verify("idtok"))
+                .thenReturn(new GoogleIdTokenService.VerifiedGoogleUser("old@example.com", "google-sub-2"));
+        when(users.findByEmail("old@example.com")).thenReturn(existing);
+        when(jwt.issue("old@example.com", 3L)).thenReturn("fake-jwt");
+
+        ResponseEntity<AuthResponse> res = controller.google(new GoogleAuthRequest("idtok"));
+
+        assertEquals(HttpStatus.OK, res.getStatusCode());
+        assertNotNull(res.getBody());
+        assertEquals("fake-jwt", res.getBody().token());
+        verify(users, never()).save(any());
+    }
+
+    @Test
+    void google_invalidToken_returns401() {
+        when(googleService.verify("badtok"))
+                .thenThrow(new GoogleIdTokenService.InvalidTokenException("bad token"));
+
+        ResponseEntity<AuthResponse> res = controller.google(new GoogleAuthRequest("badtok"));
+
+        assertEquals(HttpStatus.UNAUTHORIZED, res.getStatusCode());
+        verify(users, never()).save(any());
+        verify(jwt, never()).issue(any(), any());
+    }
+
+    @Test
+    void github_success_newUser_returnsJwtAndCreatesUser() {
+        when(githubService.exchangeCode("code123", "redir://"))
+                .thenReturn(new GitHubOAuthService.VerifiedGitHubUser("gh@example.com", "12345"));
+        when(users.findByEmail("gh@example.com")).thenReturn(null);
+        User saved = new User(8L, null, "gh@example.com", false);
+        when(users.save(any(User.class))).thenReturn(saved);
+        when(jwt.issue("gh@example.com", 8L)).thenReturn("gh-jwt");
+
+        ResponseEntity<AuthResponse> res = controller.github(new GitHubAuthRequest("code123", "redir://"));
+
+        assertEquals(HttpStatus.OK, res.getStatusCode());
+        assertNotNull(res.getBody());
+        assertEquals("gh-jwt", res.getBody().token());
+        assertEquals("gh@example.com", res.getBody().user().email());
+    }
+
+    @Test
+    void github_invalidCode_returns401() {
+        when(githubService.exchangeCode("badcode", null))
+                .thenThrow(new GitHubOAuthService.InvalidTokenException("invalid"));
+
+        ResponseEntity<AuthResponse> res = controller.github(new GitHubAuthRequest("badcode", null));
+
+        assertEquals(HttpStatus.UNAUTHORIZED, res.getStatusCode());
+        verify(users, never()).save(any());
+        verify(jwt, never()).issue(any(), any());
+    }
+}

--- a/src/test/java/com/planespotter/backend/auth/JwtAuthFilterTest.java
+++ b/src/test/java/com/planespotter/backend/auth/JwtAuthFilterTest.java
@@ -1,0 +1,88 @@
+package com.planespotter.backend.auth;
+
+import jakarta.servlet.ServletException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class JwtAuthFilterTest {
+    private static final String SECRET =
+            "test-jwt-secret-at-least-32-bytes-long-padding-padding";
+
+    private JwtService jwtService;
+    private JwtAuthFilter filter;
+
+    @BeforeEach
+    void setUp() {
+        jwtService = new JwtService(SECRET, 3600);
+        filter = new JwtAuthFilter(jwtService);
+        SecurityContextHolder.clearContext();
+    }
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void missingHeader_leavesContextEmpty() throws ServletException, IOException {
+        MockHttpServletRequest req = new MockHttpServletRequest();
+        MockHttpServletResponse res = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        filter.doFilter(req, res, chain);
+
+        assertNull(SecurityContextHolder.getContext().getAuthentication());
+    }
+
+    @Test
+    void validBearer_setsAuthenticationWithEmailAsPrincipal() throws ServletException, IOException {
+        String token = jwtService.issue("alice@example.com", 7L);
+
+        MockHttpServletRequest req = new MockHttpServletRequest();
+        req.addHeader("Authorization", "Bearer " + token);
+        MockHttpServletResponse res = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        filter.doFilter(req, res, chain);
+
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        assertNotNull(auth);
+        assertEquals("alice@example.com", auth.getName());
+        assertTrue(auth.getAuthorities().stream()
+                .anyMatch(a -> a.getAuthority().equals("ROLE_USER")));
+    }
+
+    @Test
+    void invalidBearer_leavesContextEmpty() throws ServletException, IOException {
+        MockHttpServletRequest req = new MockHttpServletRequest();
+        req.addHeader("Authorization", "Bearer not.a.valid.jwt");
+        MockHttpServletResponse res = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        filter.doFilter(req, res, chain);
+
+        assertNull(SecurityContextHolder.getContext().getAuthentication());
+    }
+
+    @Test
+    void nonBearerHeader_isIgnored() throws ServletException, IOException {
+        MockHttpServletRequest req = new MockHttpServletRequest();
+        req.addHeader("Authorization", "Basic dXNlcjpwYXNz");
+        MockHttpServletResponse res = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        filter.doFilter(req, res, chain);
+
+        assertNull(SecurityContextHolder.getContext().getAuthentication());
+    }
+}

--- a/src/test/java/com/planespotter/backend/auth/JwtServiceTest.java
+++ b/src/test/java/com/planespotter/backend/auth/JwtServiceTest.java
@@ -1,0 +1,67 @@
+package com.planespotter.backend.auth;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class JwtServiceTest {
+    // 64 chars of base64 → 48 bytes after decode → exceeds 32-byte HS256 minimum.
+    private static final String BASE64_SECRET =
+            "dGVzdC1zZWNyZXQtZm9yLXVuaXQtdGVzdHMtdGVzdC1zZWNyZXQtZm9yLXVuaXR0";
+    // 47 chars, contains '-' which is not valid standard base64.
+    private static final String RAW_SECRET = "raw-test-secret-with-non-base64-chars-1234567890";
+
+    @Test
+    void issueAndParse_roundTripsSubjectAndUid() {
+        JwtService jwt = new JwtService(BASE64_SECRET, 3600);
+        String token = jwt.issue("user@example.com", 42L);
+
+        Claims claims = jwt.parse(token);
+
+        assertEquals("user@example.com", claims.getSubject());
+        Number uid = claims.get("uid", Number.class);
+        assertNotNull(uid);
+        assertEquals(42L, uid.longValue());
+    }
+
+    @Test
+    void parse_rejectsExpiredToken() {
+        JwtService jwt = new JwtService(BASE64_SECRET, -1L); // already expired
+        String token = jwt.issue("user@example.com", 1L);
+
+        assertThrows(ExpiredJwtException.class, () -> jwt.parse(token));
+    }
+
+    @Test
+    void parse_rejectsTamperedToken() {
+        JwtService jwt = new JwtService(BASE64_SECRET, 3600);
+        String token = jwt.issue("user@example.com", 1L);
+
+        // Flip a character in the payload segment to invalidate the signature.
+        String[] parts = token.split("\\.");
+        char original = parts[1].charAt(5);
+        char swapped = original == 'A' ? 'B' : 'A';
+        String tamperedPayload = parts[1].substring(0, 5) + swapped + parts[1].substring(6);
+        String tamperedToken = parts[0] + "." + tamperedPayload + "." + parts[2];
+
+        assertThrows(JwtException.class, () -> jwt.parse(tamperedToken));
+    }
+
+    @Test
+    void constructor_rejectsShortSecret() {
+        assertThrows(IllegalStateException.class, () -> new JwtService("short", 3600));
+    }
+
+    @Test
+    void constructor_acceptsRawNonBase64Secret() {
+        // Regression test: secrets with hyphens (invalid base64 chars) should fall
+        // through the base64 attempt to the raw-bytes path, not crash on DecodingException.
+        JwtService jwt = new JwtService(RAW_SECRET, 3600);
+        String token = jwt.issue("user@example.com", 1L);
+
+        assertEquals("user@example.com", jwt.parse(token).getSubject());
+    }
+}


### PR DESCRIPTION
Added unit-test coverage for OAuth, original tests were merely context-load smoke tests (no behavior tests). 14 new tests created.
**Files**
- "JwtServiceTest.java" (5 tests) — issue/parse round-trip, expired token rejection,
  signature tampering, short-secret validation, raw non-base64 secret regression
- "JwtAuthFilterTest.java`"(4 tests) — missing/valid/invalid/non-Bearer
  Authorization header handling
- "AuthControllerTest.java" (5 tests) — Google/GitHub success paths,
  existing vs new user upsert, 401 on invalid tokens