### PR TITLE
Minor Repository/Controller fixes

### DIFF
--- a/src/main/java/com/planespotter/backend/controllers/PlaneController.java
+++ b/src/main/java/com/planespotter/backend/controllers/PlaneController.java
@@ -99,7 +99,7 @@ public class PlaneController {
         if (!planeRepository.existsById(Long.valueOf(plane.getPlane_id()))) {
             return ResponseEntity.notFound().build();
         }
-        planeRepository.updatePlaneById(plane.getPlane_id(), plane.getName());
+        planeRepository.updatePlaneById(id, plane.getName());
         return ResponseEntity.ok(plane);
     }
 

--- a/src/main/java/com/planespotter/backend/repositories/PhotoRepository.java
+++ b/src/main/java/com/planespotter/backend/repositories/PhotoRepository.java
@@ -35,7 +35,7 @@ public interface PhotoRepository extends JpaRepository<Photo, Long> {
     @Transactional
     @Modifying
     @Query(value = "UPDATE \"photo\" SET user_id = :#{#photo.user_id}, " +
-            "plane_id = :#{#photo.plane_id}, url = :#{#photo.url}", nativeQuery = true)
+            "plane_id = :#{#photo.plane_id}, url = :#{#photo.url} WHERE photo_id = #{#photo.photo_id}", nativeQuery = true)
     void updatePhoto(Photo photo);
 
     @Transactional

--- a/src/main/java/com/planespotter/backend/repositories/PlaneRepository.java
+++ b/src/main/java/com/planespotter/backend/repositories/PlaneRepository.java
@@ -30,7 +30,7 @@ public interface PlaneRepository extends JpaRepository<Plane, Long> {
 
     @Transactional
     @Modifying
-    @Query(value = "UPDATE \"plane\" SET name = :name WHERE \"plane_id\"  = :id", nativeQuery = true)
+    @Query(value = "UPDATE \"plane\" SET name = :name WHERE \"plane_id\" = :plane_id", nativeQuery = true)
     void updatePlaneById(long plane_id, String name);
 
     @Transactional


### PR DESCRIPTION
- Fixed a missing WHERE clause in PhotoRepository that caused every row to get updated instead of just one.
- Fixed a wrong id in a SQL statement in PlaneRepository
- PlaneController.updatePlane uses the pathVariable provided ID instead of the one in the plane object.